### PR TITLE
Remove unused dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,11 @@
 		"nette/bootstrap": "^2.2",
 		"nette/component-model": "^2.2",
 		"nette/di": "^2.2",
-		"nette/robot-loader": "^2.2",
 		"nette/security": "^2.2",
-		"nette/utils": "^2.2",
-		"tracy/tracy": "^2.2",
 		"latte/latte": "^2.2"
 	},
 	"require-dev": {
+		"nette/robot-loader": "^2.2",
 		"nette/tester": "~1.7"
 	},
 	"autoload": {


### PR DESCRIPTION
Packages _nette/utils_ and _tracy/tracy_ are not used anywhere. Package _nette/robot-loader_ is required only by tests.