### PR TITLE
Do not register MenuComponent factory for each menu definition

### DIFF
--- a/src/Carrooi/Menu/DI/MenuExtension.php
+++ b/src/Carrooi/Menu/DI/MenuExtension.php
@@ -66,6 +66,10 @@ final class MenuExtension extends CompilerExtension
 		$container = $builder->addDefinition($this->prefix('container'))
 			->setClass(MenuContainer::class);
 
+		$builder->addDefinition($this->prefix('component.menu'))
+			->setClass(MenuComponent::class)
+			->setImplement(IMenuComponentFactory::class);
+
 		foreach ($config as $menuName => $menu) {
 			$container->addSetup('addMenu', [
 				$this->loadMenuConfiguration($builder, $menuName, $menu),
@@ -113,10 +117,6 @@ final class MenuExtension extends CompilerExtension
 		if ($loader->getClass() === ArrayMenuLoader::class) {
 			$loader->setArguments([$this->normalizeMenuItems($config['items'])]);
 		}
-
-		$builder->addDefinition($this->prefix('component.menu'))
-			->setClass(MenuComponent::class)
-			->setImplement(IMenuComponentFactory::class);
 
 		$itemFactory = $builder->addDefinition($this->prefix('menu.'. $menuName. '.factory'))
 			->setClass(MenuItemFactory::class);


### PR DESCRIPTION
..., otherwise exception _"Service 'menu.component.menu' has already been added."_ is thrown.