### PR TITLE
Removed dependency on Nette Application

### DIFF
--- a/src/Carrooi/Menu/AbstractMenuItemsContainer.php
+++ b/src/Carrooi/Menu/AbstractMenuItemsContainer.php
@@ -6,7 +6,6 @@ namespace Carrooi\Menu;
 
 use Carrooi\Menu\LinkGenerator\ILinkGenerator;
 use Carrooi\Menu\Security\IAuthorizator;
-use Nette\Application\Application;
 use Nette\Http\Request;
 use Nette\Localization\ITranslator;
 
@@ -17,6 +16,9 @@ abstract class AbstractMenuItemsContainer implements IMenuItemsContainer
 {
 
 
+	/** @var \Carrooi\Menu\IMenu */
+	protected $menu;
+
 	/** @var \Carrooi\Menu\LinkGenerator\ILinkGenerator */
 	protected $linkGenerator;
 
@@ -25,9 +27,6 @@ abstract class AbstractMenuItemsContainer implements IMenuItemsContainer
 
 	/** @var \Carrooi\Menu\Security\IAuthorizator */
 	protected $authorizator;
-
-	/** @var \Nette\Application\Application */
-	protected $application;
 
 	/** @var \Nette\Http\Request */
 	protected $httpRequest;
@@ -39,12 +38,12 @@ abstract class AbstractMenuItemsContainer implements IMenuItemsContainer
 	private $items = [];
 
 
-	public function __construct(ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Application $application, Request $httpRequest, IMenuItemFactory $menuItemFactory)
+	public function __construct(IMenu $menu, ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Request $httpRequest, IMenuItemFactory $menuItemFactory)
 	{
+		$this->menu = $menu;
 		$this->linkGenerator = $linkGenerator;
 		$this->translator = $translator;
 		$this->authorizator = $authorizator;
-		$this->application = $application;
 		$this->httpRequest = $httpRequest;
 		$this->menuItemFactory = $menuItemFactory;
 	}
@@ -85,7 +84,7 @@ abstract class AbstractMenuItemsContainer implements IMenuItemsContainer
 
 	public function addItem(string $name, string $title, callable $fn = null): void
 	{
-		$this->items[$name] = $item = $this->menuItemFactory->create($this->linkGenerator, $this->translator, $this->authorizator, $this->application, $this->httpRequest, $this->menuItemFactory, $title);
+		$this->items[$name] = $item = $this->menuItemFactory->create($this->menu, $this->linkGenerator, $this->translator, $this->authorizator, $this->httpRequest, $this->menuItemFactory, $title);
 
 		if ($fn) {
 			$fn($item);

--- a/src/Carrooi/Menu/DI/MenuExtension.php
+++ b/src/Carrooi/Menu/DI/MenuExtension.php
@@ -13,7 +13,6 @@ use Carrooi\Menu\MenuItemFactory;
 use Carrooi\Menu\Security\OptimisticAuthorizator;
 use Carrooi\Menu\UI\IMenuComponentFactory;
 use Carrooi\Menu\UI\MenuComponent;
-use Nette\Application\Application;
 use Nette\DI\CompilerExtension;
 use Nette\DI\ContainerBuilder;
 use Nette\DI\ServiceDefinition;
@@ -127,7 +126,6 @@ final class MenuExtension extends CompilerExtension
 				$linkGenerator,
 				$translator,
 				$authorizator,
-				'@'. Application::class,
 				'@'. Http\Request::class,
 				$itemFactory,
 				$loader,

--- a/src/Carrooi/Menu/IMenu.php
+++ b/src/Carrooi/Menu/IMenu.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Carrooi\Menu;
 
+use Nette\Application\UI\Presenter;
+
 /**
  * @author David Kudera <kudera.d@gmail.com>
  */
@@ -24,5 +26,11 @@ interface IMenu extends IMenuItemsContainer
 
 
 	public function getPath(): array;
+
+
+	public function getActivePresenter(): ?Presenter;
+
+
+	public function setActivePresenter(?Presenter $link): void;
 
 }

--- a/src/Carrooi/Menu/IMenuItemFactory.php
+++ b/src/Carrooi/Menu/IMenuItemFactory.php
@@ -6,7 +6,6 @@ namespace Carrooi\Menu;
 
 use Carrooi\Menu\LinkGenerator\ILinkGenerator;
 use Carrooi\Menu\Security\IAuthorizator;
-use Nette\Application\Application;
 use Nette\Http\Request;
 use Nette\Localization\ITranslator;
 
@@ -17,6 +16,6 @@ interface IMenuItemFactory
 {
 
 
-	public function create(ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Application $application, Request $httpRequest, IMenuItemFactory $menuItemFactory, string $title): IMenuItem;
+	public function create(IMenu $menu, ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Request $httpRequest, IMenuItemFactory $menuItemFactory, string $title): IMenuItem;
 
 }

--- a/src/Carrooi/Menu/LinkGenerator/NetteLinkGenerator.php
+++ b/src/Carrooi/Menu/LinkGenerator/NetteLinkGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Carrooi\Menu\LinkGenerator;
 
 use Carrooi\Menu\IMenuItem;
-use Nette\Application\Application;
+use Nette\Application\LinkGenerator;
 
 /**
  * @author David Kudera <kudera.d@gmail.com>
@@ -14,20 +14,20 @@ final class NetteLinkGenerator implements ILinkGenerator
 {
 
 
-	/** @var \Nette\Application\Application */
-	private $application;
+	/** @var \Nette\Application\LinkGenerator */
+	private $linkGenerator;
 
 
-	public function __construct(Application $application)
+	public function __construct(LinkGenerator $linkGenerator)
 	{
-		$this->application = $application;
+		$this->linkGenerator = $linkGenerator;
 	}
 
 
 	public function link(IMenuItem $item): string
 	{
 		if (($action = $item->getAction()) !== null) {
-			return $this->application->getPresenter()->link($action, $item->getActionParameters());
+			return $this->linkGenerator->link($action, $item->getActionParameters());
 
 		} elseif (($link = $item->getLink()) !== null) {
 			return $link;

--- a/src/Carrooi/Menu/Menu.php
+++ b/src/Carrooi/Menu/Menu.php
@@ -7,7 +7,7 @@ namespace Carrooi\Menu;
 use Carrooi\Menu\LinkGenerator\ILinkGenerator;
 use Carrooi\Menu\Loaders\IMenuLoader;
 use Carrooi\Menu\Security\IAuthorizator;
-use Nette\Application\Application;
+use Nette\Application\UI\Presenter;
 use Nette\Http\Request;
 use Nette\Localization\ITranslator;
 
@@ -31,10 +31,13 @@ final class Menu extends AbstractMenuItemsContainer implements IMenu
 		'sitemap' => null,
 	];
 
+	/** @var Presenter */
+	private $activePresenter;
 
-	public function __construct(ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Application $application, Request $httpRequest, IMenuItemFactory $menuItemFactory, IMenuLoader $loader, string $name, string $menuTemplate, string $breadcrumbsTemplate, string $sitemapTemplate)
+
+	public function __construct(ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Request $httpRequest, IMenuItemFactory $menuItemFactory, IMenuLoader $loader, string $name, string $menuTemplate, string $breadcrumbsTemplate, string $sitemapTemplate)
 	{
-		parent::__construct($linkGenerator, $translator, $authorizator, $application, $httpRequest, $menuItemFactory);
+		parent::__construct($this, $linkGenerator, $translator, $authorizator, $httpRequest, $menuItemFactory);
 
 		$this->loader = $loader;
 		$this->name = $name;
@@ -90,6 +93,18 @@ final class Menu extends AbstractMenuItemsContainer implements IMenu
 		}
 
 		return $path;
+	}
+
+
+	public function getActivePresenter(): ?Presenter
+	{
+		return $this->activePresenter;
+	}
+
+
+	public function setActivePresenter(?Presenter $presenter): void
+	{
+		$this->activePresenter = $presenter;
 	}
 
 }

--- a/src/Carrooi/Menu/MenuItem.php
+++ b/src/Carrooi/Menu/MenuItem.php
@@ -6,7 +6,6 @@ namespace Carrooi\Menu;
 
 use Carrooi\Menu\LinkGenerator\ILinkGenerator;
 use Carrooi\Menu\Security\IAuthorizator;
-use Nette\Application\Application;
 use Nette\Application\UI\InvalidLinkException;
 use Nette\Http\Request;
 use Nette\Localization\ITranslator;
@@ -46,9 +45,10 @@ final class MenuItem extends AbstractMenuItemsContainer implements IMenuItem
 	/** @var string[] */
 	private $include = [];
 
-	public function __construct(ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Application $application, Request $httpRequest, IMenuItemFactory $menuItemFactory, string $title)
+
+	public function __construct(IMenu $menu, ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Request $httpRequest, IMenuItemFactory $menuItemFactory, string $title)
 	{
-		parent::__construct($linkGenerator, $translator, $authorizator, $application, $httpRequest, $menuItemFactory);
+		parent::__construct($menu, $linkGenerator, $translator, $authorizator, $httpRequest, $menuItemFactory);
 
 		$this->title = $title;
 	}
@@ -64,10 +64,7 @@ final class MenuItem extends AbstractMenuItemsContainer implements IMenuItem
 			return $this->active = false;
 		}
 
-		if ($this->getAction()) {
-
-			/** @var \Nette\Application\UI\Presenter $presenter */
-			$presenter = $this->application->getPresenter();
+		if ($this->getAction() && ($presenter = $this->menu->getActivePresenter())) {
 
 			try {
 				$presenter->link($this->getAction(), $this->getActionParameters());

--- a/src/Carrooi/Menu/MenuItemFactory.php
+++ b/src/Carrooi/Menu/MenuItemFactory.php
@@ -6,7 +6,6 @@ namespace Carrooi\Menu;
 
 use Carrooi\Menu\LinkGenerator\ILinkGenerator;
 use Carrooi\Menu\Security\IAuthorizator;
-use Nette\Application\Application;
 use Nette\Http\Request;
 use Nette\Localization\ITranslator;
 
@@ -17,9 +16,9 @@ final class MenuItemFactory implements IMenuItemFactory
 {
 
 
-	public function create(ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Application $application, Request $httpRequest, IMenuItemFactory $menuItemFactory, string $title): IMenuItem
+	public function create(IMenu $menu, ILinkGenerator $linkGenerator, ITranslator $translator, IAuthorizator $authorizator, Request $httpRequest, IMenuItemFactory $menuItemFactory, string $title): IMenuItem
 	{
-		return new MenuItem($linkGenerator, $translator, $authorizator, $application, $httpRequest, $menuItemFactory, $title);
+		return new MenuItem($menu, $linkGenerator, $translator, $authorizator, $httpRequest, $menuItemFactory, $title);
 	}
 
 }

--- a/src/Carrooi/Menu/UI/MenuComponent.php
+++ b/src/Carrooi/Menu/UI/MenuComponent.php
@@ -7,6 +7,7 @@ namespace Carrooi\Menu\UI;
 use Carrooi\Menu\IMenu;
 use Carrooi\Menu\MenuContainer;
 use Nette\Application\UI\Control;
+use Nette\Application\UI\Presenter;
 
 /**
  * @author David Kudera <kudera.d@gmail.com>
@@ -58,6 +59,23 @@ final class MenuComponent extends Control
 		$this->template->menu = $menu;
 
 		$this->template->render();
+	}
+
+
+	/**
+	 * This method will be called when the component (or component's parent)
+	 * becomes attached to a monitored object. Do not call this method yourself.
+	 * @param  \Nette\ComponentModel\IComponent
+	 * @return void
+	 */
+	protected function attached($presenter)
+	{
+		if ($presenter instanceof Presenter) {
+			$menu = $this->container->getMenu($this->menuName);
+			$menu->setActivePresenter($presenter);
+		}
+
+		parent::attached($presenter);
 	}
 
 }

--- a/tests/CarrooiTests/Menu/AbstractMenuItemsContainerTest.phpt
+++ b/tests/CarrooiTests/Menu/AbstractMenuItemsContainerTest.phpt
@@ -19,10 +19,10 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 	public function testItems(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$item = $this->createMockMenuItem();
 
@@ -30,7 +30,7 @@ final class AbstractMenuItemsContainerTest extends TestCase
 			$itemFactory->shouldReceive('create')->andReturn($item);
 		});
 
-		$container = $this->createPartialMockAbstractMenuItemsContainer(null, [$linkGenerator, $translator, $authorizator, $application, $request, $itemFactory]);
+		$container = $this->createPartialMockAbstractMenuItemsContainer(null, [$menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory]);
 
 		Assert::equal([], $container->getItems());
 
@@ -44,10 +44,10 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 	public function testGetItem_direct(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -55,7 +55,7 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 		$container = $this->createPartialMockAbstractMenuItemsContainer(function(MockInterface $container) use ($item) {
 			$container->shouldReceive('getItems')->andReturn(['item' => $item]);
-		}, [$linkGenerator, $translator, $authorizator, $application, $request, $itemFactory]);
+		}, [$menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory]);
 
 		Assert::same($item, $container->getItem('item'));
 	}
@@ -63,10 +63,10 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 	public function testGetItem(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -82,7 +82,7 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 		$container = $this->createPartialMockAbstractMenuItemsContainer(function(MockInterface $container) use ($itemA) {
 			$container->shouldReceive('getItems')->andReturn(['a' => $itemA]);
-		}, [$linkGenerator, $translator, $authorizator, $application, $request, $itemFactory]);
+		}, [$menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory]);
 
 		Assert::same($itemC, $container->getItem('a-b-c'));
 	}
@@ -90,10 +90,10 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 	public function testFindActiveItem(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -116,7 +116,7 @@ final class AbstractMenuItemsContainerTest extends TestCase
 				'b' => $itemB,
 				'c' => $itemC,
 			]);
-		}, [$linkGenerator, $translator, $authorizator, $application, $request, $itemFactory]);
+		}, [$menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory]);
 
 		Assert::same($itemC, $container->findActiveItem());
 	}
@@ -124,10 +124,10 @@ final class AbstractMenuItemsContainerTest extends TestCase
 
 	public function testVisibleItemsOn(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -148,7 +148,7 @@ final class AbstractMenuItemsContainerTest extends TestCase
 				'a' => $itemA,
 				'b' => $itemB,
 			]);
-		}, [$linkGenerator, $translator, $authorizator, $application, $request, $itemFactory]);
+		}, [$menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory]);
 
 		Assert::true($container->hasVisibleItemsOnMenu());
 		Assert::equal(['b' => $itemB], $container->getVisibleItemsOnMenu());

--- a/tests/CarrooiTests/Menu/LinkGenerator/NetteLinkGeneratorTest.phpt
+++ b/tests/CarrooiTests/Menu/LinkGenerator/NetteLinkGeneratorTest.phpt
@@ -20,12 +20,8 @@ final class NetteLinkGeneratorTest extends TestCase
 
 	public function testLink_action(): void
 	{
-		$application = $this->createMockApplication(function(MockInterface $application) {
-			$application->shouldReceive('getPresenter')->andReturn(
-				$this->createMockPresenter(function(MockInterface $presenter) {
-					$presenter->shouldReceive('link')->andReturn('/');
-				})
-			);
+		$netteLinkGenerator = $this->createMockNetteLinkGenerator(function(MockInterface $netteLinkGenerator) {
+			$netteLinkGenerator->shouldReceive('link')->andReturn('/');
 		});
 
 		$item = $this->createMockMenuItem(function(MockInterface $item) {
@@ -33,7 +29,7 @@ final class NetteLinkGeneratorTest extends TestCase
 			$item->shouldReceive('getActionParameters')->andReturn([]);
 		});
 
-		$linkGenerator = new NetteLinkGenerator($application);
+		$linkGenerator = new NetteLinkGenerator($netteLinkGenerator);
 
 		Assert::same('/', $linkGenerator->link($item));
 	}
@@ -41,14 +37,16 @@ final class NetteLinkGeneratorTest extends TestCase
 
 	public function testLink_link(): void
 	{
-		$application = $this->createMockApplication();
+		$netteLinkGenerator = $this->createMockNetteLinkGenerator(function(MockInterface $netteLinkGenerator) {
+			$netteLinkGenerator->shouldReceive('link')->andReturn('/');
+		});
 
 		$item = $this->createMockMenuItem(function(MockInterface $item) {
 			$item->shouldReceive('getAction')->andReturn(null);
 			$item->shouldReceive('getLink')->andReturn('/');
 		});
 
-		$linkGenerator = new NetteLinkGenerator($application);
+		$linkGenerator = new NetteLinkGenerator($netteLinkGenerator);
 
 		Assert::same('/', $linkGenerator->link($item));
 	}
@@ -56,14 +54,16 @@ final class NetteLinkGeneratorTest extends TestCase
 
 	public function testLink(): void
 	{
-		$application = $this->createMockApplication();
+		$netteLinkGenerator = $this->createMockNetteLinkGenerator(function(MockInterface $netteLinkGenerator) {
+			$netteLinkGenerator->shouldReceive('link')->andReturn('/');
+		});
 
 		$item = $this->createMockMenuItem(function(MockInterface $item) {
 			$item->shouldReceive('getAction')->andReturn(null);
 			$item->shouldReceive('getLink')->andReturn(null);
 		});
 
-		$linkGenerator = new NetteLinkGenerator($application);
+		$linkGenerator = new NetteLinkGenerator($netteLinkGenerator);
 
 		Assert::same('#', $linkGenerator->link($item));
 	}

--- a/tests/CarrooiTests/Menu/MenuItemFactoryTest.phpt
+++ b/tests/CarrooiTests/Menu/MenuItemFactoryTest.phpt
@@ -22,15 +22,15 @@ final class MenuItemFactoryTest extends TestCase
 
 	public function testCreate(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
 		$factory = new MenuItemFactory;
-		$item = $factory->create($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = $factory->create($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::type(IMenuItem::class, $item);
 	}

--- a/tests/CarrooiTests/Menu/MenuItemTest.phpt
+++ b/tests/CarrooiTests/Menu/MenuItemTest.phpt
@@ -24,15 +24,23 @@ final class MenuItemTest extends TestCase
 	{
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
+
+		$menu = $this->createMockMenu(function (MockInterface $menu) {
+			$menu->shouldReceive('getActivePresenter')->andReturn(
+				$this->createMockPresenter(function(MockInterface $presenter) {
+					$presenter->shouldReceive('link')->andReturn('#');
+					$presenter->shouldReceive('getLastCreatedRequestFlag')->andReturn(true);
+				})
+			);
+		});
 
 		$authorizator = $this->createMockAuthorizator(function(MockInterface $authorizator) {
 			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(true);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::true($item->isAllowed());
 	}
@@ -42,15 +50,23 @@ final class MenuItemTest extends TestCase
 	{
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
+
+		$menu = $this->createMockMenu(function (MockInterface $menu) {
+			$menu->shouldReceive('getActivePresenter')->andReturn(
+				$this->createMockPresenter(function(MockInterface $presenter) {
+					$presenter->shouldReceive('link')->andReturn('#');
+					$presenter->shouldReceive('getLastCreatedRequestFlag')->andReturn(true);
+				})
+			);
+		});
 
 		$authorizator = $this->createMockAuthorizator(function(MockInterface $authorizator) {
 			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(false);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::false($item->isActive());
 	}
@@ -63,12 +79,8 @@ final class MenuItemTest extends TestCase
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$authorizator = $this->createMockAuthorizator(function(MockInterface $authorizator) {
-			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(true);
-		});
-
-		$application = $this->createMockApplication(function(MockInterface $application) {
-			$application->shouldReceive('getPresenter')->andReturn(
+		$menu = $this->createMockMenu(function (MockInterface $menu) {
+			$menu->shouldReceive('getActivePresenter')->andReturn(
 				$this->createMockPresenter(function(MockInterface $presenter) {
 					$presenter->shouldReceive('link')->andReturn('#');
 					$presenter->shouldReceive('getLastCreatedRequestFlag')->andReturn(true);
@@ -76,7 +88,11 @@ final class MenuItemTest extends TestCase
 			);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$authorizator = $this->createMockAuthorizator(function(MockInterface $authorizator) {
+			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(true);
+		});
+
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 		$item->setAction('Home:');
 
 		Assert::true($item->isActive());
@@ -89,12 +105,8 @@ final class MenuItemTest extends TestCase
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$authorizator = $this->createMockAuthorizator(function(MockInterface $authorizator) {
-			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(true);
-		});
-
-		$application = $this->createMockApplication(function(MockInterface $application) {
-			$application->shouldReceive('getPresenter')->andReturn(
+		$menu = $this->createMockMenu(function (MockInterface $menu) {
+			$menu->shouldReceive('getActivePresenter')->andReturn(
 				$this->createMockPresenter(function(MockInterface $presenter) {
 					$presenter->shouldReceive('link')->andReturn('#');
 					$presenter->shouldReceive('getLastCreatedRequestFlag')->andReturn(false);
@@ -104,7 +116,11 @@ final class MenuItemTest extends TestCase
 			);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$authorizator = $this->createMockAuthorizator(function(MockInterface $authorizator) {
+			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(true);
+		});
+
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 		$item->setAction('Home:');
 		$item->setInclude([
 			'^Home\:[a-zA-Z\:]+$'
@@ -115,9 +131,9 @@ final class MenuItemTest extends TestCase
 
 	public function testIsActive_active_child(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 
 		$itemFactory = $this->createMockMenuItemFactory(function(MockInterface $itemFactory) {
@@ -133,7 +149,7 @@ final class MenuItemTest extends TestCase
 			$authorizator->shouldReceive('isMenuItemAllowed')->andReturn(true);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 		$item->addItem('child', 'Child');
 
 		Assert::true($item->isActive());
@@ -142,14 +158,14 @@ final class MenuItemTest extends TestCase
 
 	public function testAction(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::null($item->getAction());
 		Assert::equal([], $item->getActionParameters());
@@ -163,14 +179,14 @@ final class MenuItemTest extends TestCase
 
 	public function testLink(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::null($item->getLink());
 
@@ -182,9 +198,9 @@ final class MenuItemTest extends TestCase
 
 	public function testGetRealTitle(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -192,7 +208,7 @@ final class MenuItemTest extends TestCase
 			$translator->shouldReceive('translate')->andReturn('ITEM');
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::same('ITEM', $item->getRealTitle());
 	}
@@ -200,9 +216,9 @@ final class MenuItemTest extends TestCase
 
 	public function testGetRealLink(): void
 	{
+		$menu = $this->createMockMenu();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -210,7 +226,7 @@ final class MenuItemTest extends TestCase
 			$linkGenerator->shouldReceive('link')->andReturn('#');
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::same('#', $item->getRealLink());
 	}
@@ -218,9 +234,9 @@ final class MenuItemTest extends TestCase
 
 	public function testGetRealAbsoluteLink_80_port(): void
 	{
+		$menu = $this->createMockMenu();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$itemFactory = $this->createMockMenuItemFactory();
 
 		$linkGenerator = $this->createMockLinkGenerator(function(MockInterface $linkGenerator) {
@@ -237,7 +253,7 @@ final class MenuItemTest extends TestCase
 			);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::same('https://localhost/', $item->getRealAbsoluteLink());
 	}
@@ -245,9 +261,9 @@ final class MenuItemTest extends TestCase
 
 	public function testGetRealAbsoluteLink(): void
 	{
+		$menu = $this->createMockMenu();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$itemFactory = $this->createMockMenuItemFactory();
 
 		$linkGenerator = $this->createMockLinkGenerator(function(MockInterface $linkGenerator) {
@@ -264,7 +280,7 @@ final class MenuItemTest extends TestCase
 			);
 		});
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::same('https://localhost:8080/', $item->getRealAbsoluteLink());
 	}
@@ -272,14 +288,14 @@ final class MenuItemTest extends TestCase
 
 	public function testGetData(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 		$item->setData(['test' => 'data']);
 
 		Assert::equal('data', $item->getData('test'));
@@ -288,14 +304,14 @@ final class MenuItemTest extends TestCase
 
 	public function testGetData_default(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::equal('default', $item->getData('test', 'default'));
 	}
@@ -303,14 +319,14 @@ final class MenuItemTest extends TestCase
 
 	public function testAddData(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 		$item->addData('test', 'data');
 
 		Assert::true($item->hasData('test'));
@@ -320,14 +336,14 @@ final class MenuItemTest extends TestCase
 
 	public function testVisibility(): void
 	{
+		$menu = $this->createMockMenu();
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
-		$item = new MenuItem($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, 'item');
+		$item = new MenuItem($menu, $linkGenerator, $translator, $authorizator, $request, $itemFactory, 'item');
 
 		Assert::true($item->isVisibleOnMenu());
 		$item->setMenuVisibility(false);

--- a/tests/CarrooiTests/Menu/MenuTest.phpt
+++ b/tests/CarrooiTests/Menu/MenuTest.phpt
@@ -28,7 +28,6 @@ final class MenuTest extends TestCase
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 
@@ -36,7 +35,7 @@ final class MenuTest extends TestCase
 			$loader->shouldReceive('load');
 		});
 
-		$menu = new Menu($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, $loader, 'menu', '', '', '');
+		$menu = new Menu($linkGenerator, $translator, $authorizator, $request, $itemFactory, $loader, 'menu', '', '', '');
 		$menu->init();
 	}
 
@@ -46,12 +45,11 @@ final class MenuTest extends TestCase
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 		$loader = $this->createMockMenuLoader();
 
-		$menu = new Menu($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, $loader, 'menu', '', '', '');
+		$menu = new Menu($linkGenerator, $translator, $authorizator, $request, $itemFactory, $loader, 'menu', '', '', '');
 
 		Assert::same('menu', $menu->getName());
 	}
@@ -62,12 +60,11 @@ final class MenuTest extends TestCase
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$itemFactory = $this->createMockMenuItemFactory();
 		$loader = $this->createMockMenuLoader();
 
-		$menu = new Menu($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, $loader, 'menu', 'menu-template.latte', 'breadcrumbs-template.latte', 'sitemap-template.latte');
+		$menu = new Menu($linkGenerator, $translator, $authorizator, $request, $itemFactory, $loader, 'menu', 'menu-template.latte', 'breadcrumbs-template.latte', 'sitemap-template.latte');
 
 		Assert::same('menu-template.latte', $menu->getMenuTemplate());
 		Assert::same('breadcrumbs-template.latte', $menu->getBreadcrumbsTemplate());
@@ -80,7 +77,6 @@ final class MenuTest extends TestCase
 		$linkGenerator = $this->createMockLinkGenerator();
 		$translator = $this->createMockTranslator();
 		$authorizator = $this->createMockAuthorizator();
-		$application = $this->createMockApplication();
 		$request = $this->createMockHttpRequest();
 		$loader = $this->createMockMenuLoader();
 
@@ -106,7 +102,7 @@ final class MenuTest extends TestCase
 			$itemFactory->shouldReceive('create')->andReturn($itemA);
 		});
 
-		$menu = new Menu($linkGenerator, $translator, $authorizator, $application, $request, $itemFactory, $loader, 'menu', '', '', '');
+		$menu = new Menu($linkGenerator, $translator, $authorizator, $request, $itemFactory, $loader, 'menu', '', '', '');
 		$menu->addItem('a','ItemA');
 
 		Assert::equal([

--- a/tests/CarrooiTests/TestCase.php
+++ b/tests/CarrooiTests/TestCase.php
@@ -14,7 +14,8 @@ use Carrooi\Menu\Menu;
 use Carrooi\Menu\Security\IAuthorizator;
 use Mockery\MockInterface;
 use Nette\Application\Application;
-use Nette\Application\IPresenter;
+use Nette\Application\LinkGenerator;
+use Nette\Application\UI\Presenter;
 use Nette\Http\Request;
 use Nette\Http\Url;
 use Nette\Localization\ITranslator;
@@ -69,6 +70,12 @@ abstract class TestCase extends Tester\TestCase
 	}
 
 
+	protected function createMockNetteLinkGenerator(callable $fn = null): LinkGenerator
+	{
+		return $this->createMock(LinkGenerator::class, $fn);
+	}
+
+
 	protected function createMockTranslator(callable $fn = null): ITranslator
 	{
 		return $this->createMock(ITranslator::class, $fn);
@@ -87,9 +94,9 @@ abstract class TestCase extends Tester\TestCase
 	}
 
 
-	protected function createMockPresenter(callable $fn = null): IPresenter
+	protected function createMockPresenter(callable $fn = null): Presenter
 	{
-		return $this->createMock(IPresenter::class, $fn);
+		return $this->createMock(Presenter::class, $fn);
 	}
 
 


### PR DESCRIPTION
Sometimes, especially in Presenter tests, there is no presenter set in Application and menu doesn't work as expected.

What was changed:
* `Application` is comepletely not needed
* `AbstractMenuItemsContainer` now depends on `IMenu`
* `Presenter` is set to `Menu` using `attached()` method

This is probably BC break, but I could run this version without any changes in application.