### PR TITLE
Nette 2.4. and PHP 5.6. compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 		"issues": "https://github.com/Carrooi/Nette-Menu/issues"
 	},
 	"require": {
-		"nette/nette": ">= 2.2.0"
+		"php": ">=5.6.0 <7.0.0", 
+		"nette/nette": "~2.4.0"
 	},
 	"require-dev": {
 		"nette/tester": "@dev"

--- a/src/DK/Menu/Menu.php
+++ b/src/DK/Menu/Menu.php
@@ -33,8 +33,9 @@ class Menu extends Container
 	{
 		parent::__construct();
 
+		// E_USER_DEPRECATED fix - Nette\ComponentModel\Component::__construct() argument $name is deprecated, use $parent->setParent(null, $name) instead.
 		$parent = $this->getParent();
-		if ($parent !== NULL) {
+		if ($parent !== null) {
 			$parent->setParent(null, $name);
 		}
 

--- a/src/DK/Menu/Menu.php
+++ b/src/DK/Menu/Menu.php
@@ -31,7 +31,12 @@ class Menu extends Container
 	 */
 	public function __construct(User $user, $name)
 	{
-		parent::__construct(null, $name);
+		parent::__construct();
+
+		$parent = $this->getParent();
+		if ($parent !== NULL) {
+			$parent->setParent(null, $name);
+		}
 
 		$this->user = $user;
 	}


### PR DESCRIPTION
What about new branche for PHP 5.6. and Nette 2.4.? Just for fix deprecated errors? 
I have projects on PHP 5.6 with Nette 2.4. 
For PHP 5.6. and Nette 2.4. composer installs carrooi/nette-menu v1.1.1 , but there are deprecated errors. Is this solution possible?

This convention seems to be logic:
- v1.x.x - < PHP 7
- v2.x.x - >= PHP 7 
- v1.0.x - Nette 2.1.
- v1.1.x - Nette 2.2. and 2.3.
- v1.2.x - Nette 2.4
